### PR TITLE
Add Giscus comments to site pages

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -3,3 +3,23 @@
 This page tells you a little bit about this simple site.
 
 We built this site to demonstrate how to organize a static site using Markdown files and directories on GitHub.
+
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/aerolink/index.md
+++ b/aerolink/index.md
@@ -104,3 +104,23 @@ This is how cities can grow not just outward, or upward, but **together** — a 
 ---
 
 *If you're interested in a downloadable concept brief, illustrations, or a policy template to propose this to planners or developers, I can help draft those next.*
+
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/ambient/index.md
+++ b/ambient/index.md
@@ -44,3 +44,23 @@ This concept is built on a few core beliefs about how technology should connect 
 * **Trust and Intimacy:** As a dedicated, closed system for a pre-defined circle, it creates a trusted space for connection, free from the noise of wider social networks.
 
 Ultimately, this is an exploration of how we can use technology not to schedule our relationships, but to let them breathe. It's a move toward a calmer, more present, and more human way of staying in touch.
+
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/contact/index.md
+++ b/contact/index.md
@@ -3,3 +3,23 @@
 This page provides contact information.
 
 You can reach me by opening an issue on this repository or sending an email to example@example.com (replace with your email).
+
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/echo/index.md
+++ b/echo/index.md
@@ -56,3 +56,23 @@ EchoBoard is more than just a keyboard; it's a design philosophy.
 * **It’s a true thought partner.** By allowing for iterative, conversational refinement, EchoBoard helps you explore ideas and find the right words, turning the chore of writing into a creative process.
 
 The future of human-computer interaction lies in creating tools that adapt to us. EchoBoard is a step in that direction—a keyboard that doesn't just listen, but understands.
+
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/gourmet/index.md
+++ b/gourmet/index.md
@@ -95,3 +95,22 @@ Let’s define the standard, build the first smart cooker, and launch the “Laz
 
 *Interested in collaborating or seeing a prototype?*  
 Contact: [your preferred contact link or email here]  
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/index.md
+++ b/index.md
@@ -10,3 +10,22 @@ This is the home page of my simple static website. Navigate through the pages to
 - [Fly in cloud](/fly/index.md)
 - [Echo Board](/echo/index.md)
 - [Ambient Audio](/ambient/index.md)
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/personal_virtual_embassy/index.md
+++ b/personal_virtual_embassy/index.md
@@ -104,3 +104,23 @@ escalation:
   missed_deadline_threshold_days: 2
   ambiguous_request: require_user_confirmation
 `````
+
+---
+
+<script src="https://giscus.app/client.js"
+        data-repo="akrafts-gpt/simple-static-site"
+        data-repo-id="R_kgDOPWwKHQ"
+        data-category="Ideas"
+        data-category-id="DIC_kwDOPWwKHc4CtsPi"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+


### PR DESCRIPTION
## Summary
- embed Giscus comment widget on home page and all major subpages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dacdea13483229b104f0863fd114a