### PR TITLE
docs: add article summaries to homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,15 +2,15 @@
 
 This is the home page of my simple static website. Navigate through the pages to learn more.
 
-- [About](/about/index.md)
-- [Contact](/contact/index.md)
-- [Personal Virtual Embassy](/personal_virtual_embassy/index.md)
-- [Gourmet vending](/gourmet/index.md)
-- [AEROLINK](/aerolink/index.md)
-- [Fly in cloud](/fly/index.md)
-- [Echo Board](/echo/index.md)
-- [Ambient Audio](/ambient/index.md)
-- [Tribe To Fly](/tribe-to-fly/index.md)
+- [About](/about/index.md) – Explains this site as a demo of organizing static content with Markdown files and directories on GitHub.
+- [Contact](/contact/index.md) – Offers ways to reach the author via GitHub issues or email for questions and collaboration.
+- [Personal Virtual Embassy](/personal_virtual_embassy/index.md) – Proposes an AI ambassador that retains context, adapts tone, and negotiates small tasks within user-defined boundaries.
+- [Gourmet vending](/gourmet/index.md) – Suggests standardized smart meal pods with encoded cook profiles and ovens that automatically prepare quality frozen meals.
+- [AEROLINK](/aerolink/index.md) – Introduces a modular cable-guided pod network linking sky lobbies to create a scalable 3D transit mesh for cities.
+- [Fly in cloud](/fly/index.md) – Reimagines aircraft cabins with inflatable, body-conforming pods that adapt to posture and enable flexible travel experiences.
+- [Echo Board](/echo/index.md) – Envisions a mobile keyboard that toggles between classic typing and an AI voice mode with gesture-driven controls.
+- [Ambient Audio](/ambient/index.md) – Describes a tactile device with tuning and presence wheels for low-pressure, always-on voice connections with loved ones.
+- [Tribe To Fly](/tribe-to-fly/index.md) – Explores forming temporary travel crews who match by vibe, pool funds, and book shared stays for richer adventures.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add concise 1-2 sentence descriptions for each article on the homepage index

## Testing
- `npx markdownlint index.md` *(fails: 403 Forbidden)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688daf81c278832293e647bda1b4cd5a