### PR TITLE
Personalize about page and adjust home link order

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -1,8 +1,10 @@
 # About
 
-This page tells you a little bit about this simple site.
+This site is my personal corner of the web where I collect and share ideas.
 
-We built this site to demonstrate how to organize a static site using Markdown files and directories on GitHub.
+Instead of placeholder examples or old templates, you'll find notes on concepts I'm exploring and other thoughts in progress.
+
+Feel free to look around and see what I'm working on.
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -2,7 +2,6 @@
 
 This is the home page of my simple static website. Navigate through the pages to learn more.
 
-- [About](/about/index.md) – Explains this site as a demo of organizing static content with Markdown files and directories on GitHub.
 - [Contact](/contact/index.md) – Offers ways to reach the author via GitHub issues or email for questions and collaboration.
 - [Personal Virtual Embassy](/personal_virtual_embassy/index.md) – Proposes an AI ambassador that retains context, adapts tone, and negotiates small tasks within user-defined boundaries.
 - [Gourmet vending](/gourmet/index.md) – Suggests standardized smart meal pods with encoded cook profiles and ovens that automatically prepare quality frozen meals.
@@ -11,6 +10,7 @@ This is the home page of my simple static website. Navigate through the pages to
 - [Echo Board](/echo/index.md) – Envisions a mobile keyboard that toggles between classic typing and an AI voice mode with gesture-driven controls.
 - [Ambient Audio](/ambient/index.md) – Describes a tactile device with tuning and presence wheels for low-pressure, always-on voice connections with loved ones.
 - [Tribe To Fly](/tribe-to-fly/index.md) – Explores forming temporary travel crews who match by vibe, pool funds, and book shared stays for richer adventures.
+- [About](/about/index.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- Move About link to the bottom of the home page list and remove its description
- Rewrite About page with personal context and idea sharing

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688db6bdd4b483229a0e7ee746bdb14e