### PR TITLE
Revert theme merge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,0 @@
-title: Simple Static Site
-description: A simple static site with dark and light themes.
-theme: jekyll-theme-primer

--- a/about/index.md
+++ b/about/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # About
 
 This site is my personal corner of the web where I collect and share ideas.
@@ -22,7 +18,7 @@ Feel free to look around and see what I'm working on.
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/aerolink/index.md
+++ b/aerolink/index.md
@@ -1,8 +1,4 @@
 ---
-layout: default
----
-
----
 title: "AEROLINK: Rethinking Vertical Cities with a 3D Cable-Pod Transit Mesh"
 date: 2025-08-01
 ---
@@ -121,7 +117,7 @@ This is how cities can grow not just outward, or upward, but **together** — a 
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/ambient/index.md
+++ b/ambient/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # Beyond the Call: An Idea for an Ambient Audio Companion
 
 In a world of scheduled video calls and instant messages demanding our immediate attention, staying connected with the people we care about can sometimes feel more like a task than a joy. The natural, effortless flow of simply *being* in the same space with someone is lost. We stare at unflattering camera angles, we feel the pressure to perform, and we lose the gentle, low-pressure presence that defines our closest relationships.
@@ -61,7 +57,7 @@ Ultimately, this is an exploration of how we can use technology not to schedule 
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/contact/index.md
+++ b/contact/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # Contact
 
 This page provides contact information.
@@ -20,7 +16,7 @@ You can reach me by opening an issue on this repository or sending an email to e
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/echo/index.md
+++ b/echo/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # EchoBoard: A Concept for a Smarter, More Human Keyboard
 
 We've all been there. Staring at a tiny screen, trying to compose the perfect reply. We type, delete, re-read, and re-phrase. Our mobile keyboards are functional tools for transcription, but what if they could be more? What if they could be our partners in communication?
@@ -73,7 +69,7 @@ The future of human-computer interaction lies in creating tools that adapt to us
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/fly/index.md
+++ b/fly/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # Flying in the Cloud: Reimagining Aircraft Seating as Inflatable, Body-Conforming Pods
 
 Most cabins today are organized around fixed categories—economy, premium, business—each defined by static seats bolted to the floor. What if instead of immutable benches, the cabin became a **transformable environment** that adapts to people, moods, and phases of a flight? What if passengers didn’t sit “on” the plane so much as **float inside a soft, adaptive cradle** tailored to their body and desired experience?
@@ -94,7 +90,7 @@ This isn’t a seat upgrade; it’s a **paradigm shift in what it means to occup
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/gourmet/index.md
+++ b/gourmet/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # Lazy Gourmet: Standardized Smart-Meal Pods + Automated Cooking
 
 A simple, high-leverage idea: combine unified frozen meal packaging with smart ovens (in vending or standalone) that *read* the package and cook it automatically—no thinking, minimal input, quality result.
@@ -111,7 +107,7 @@ Contact: [your preferred contact link or email here]
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/index.md
+++ b/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # Welcome to My Simple Site
 
 This is the home page of my simple static website. Navigate through the pages to learn more.
@@ -28,7 +24,7 @@ This is the home page of my simple static website. Navigate through the pages to
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/personal_virtual_embassy/index.md
+++ b/personal_virtual_embassy/index.md
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 # Personal Virtual Embassy: AI as Your Digital Ambassador
 
 ## Overview
@@ -121,7 +117,7 @@ escalation:
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"

--- a/tribe-to-fly/index.md
+++ b/tribe-to-fly/index.md
@@ -1,8 +1,4 @@
 ---
-layout: default
----
-
----
 title: Travel Together: A Community-First Way to Share Short-Term Stays
 subtitle: Building temporary travel crews for richer, social adventures
 ---
@@ -121,7 +117,7 @@ Drop your thoughts in the comments, DM me, or email me—this concept lives or d
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-input-position="bottom"
-        data-theme="preferred_color_scheme"
+        data-theme="light"
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"


### PR DESCRIPTION
## Summary
- Revert previous merge that applied the Primer theme and automatic color scheme
- Remove `_config.yml` and theme front matter from site pages

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*
- `gem install jekyll -N` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688dcf3dc078832294aa318ac66c9019