### PR TITLE
Fix navigation across maps articles

### DIFF
--- a/maps/ai/index.md
+++ b/maps/ai/index.md
@@ -1,17 +1,18 @@
 # AI-Generated Instant Sites  
 *From map pin to mobile-ready microsite in under 10 minutes—no code, no hassle.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [Where Bad Sites Come From](#where-bad-sites-come-from)  
-> • [PDF Menus → Microsites](#pdf-menus-→-microsites)  
-> • [Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)  
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)
+> • [Time-Slot Deals for Any Business](../time/)
 > • **AI-Generated Instant Sites** (you are here)  
-> • [Curating Google Maps Listings](#curating-google-maps-listings)  
-> • [The Microsite Flywheel](#the-microsite-flywheel)  
-> • [A Freemium Model Owners Trust](#a-freemium-model-owners-trust)  
-> • [Roadmap & Next Steps](#roadmap--next-steps)
+> • [Curating Google Maps Listings](../curate/)  
+> • [The Microsite Flywheel](../fly/)  
+> • [A Freemium Model Owners Trust](../price/)  
+> • [Roadmap & Next Steps](../next/)
 
 ---
 

--- a/maps/curate/index.md
+++ b/maps/curate/index.md
@@ -1,17 +1,18 @@
 # Curating Google Maps Listings  
 *How to layer owner-approved content on top of the world’s biggest POI database—without breaking UX or Google’s rules.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [Where Bad Sites Come From](#where-bad-sites-come-from)  
-> • [PDF Menus → Microsites](#pdf-menus-→-microsites)  
-> • [Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)  
-> • [AI-Generated Instant Sites](#ai-generated-instant-sites)  
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)  
+> • [Time-Slot Deals for Any Business](../time/)  
+> • [AI-Generated Instant Sites](../ai/)  
 > • **Curating Google Maps Listings** (you are here)  
-> • [The Microsite Flywheel](#the-microsite-flywheel)  
-> • [A Freemium Model Owners Trust](#a-freemium-model-owners-trust)  
-> • [Roadmap & Next Steps](#roadmap--next-steps)
+> • [The Microsite Flywheel](../fly/)  
+> • [A Freemium Model Owners Trust](../price/)  
+> • [Roadmap & Next Steps](../next/)
 
 ---
 

--- a/maps/fly/index.md
+++ b/maps/fly/index.md
@@ -1,17 +1,18 @@
 # The Microsite Flywheel  
 *How interconnected, Google-Maps-first pages drive compounding traffic, bookings, and trust for local businesses.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [Where Bad Sites Come From](#where-bad-sites-come-from)  
-> • [PDF Menus → Microsites](#pdf-menus-→-microsites)  
-> • [Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)  
-> • [AI-Generated Instant Sites](#ai-generated-instant-sites)  
-> • [Curating Google Maps Listings](#curating-google-maps-listings)  
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)  
+> • [Time-Slot Deals for Any Business](../time/)  
+> • [AI-Generated Instant Sites](../ai/)  
+> • [Curating Google Maps Listings](../curate/)  
 > • **The Microsite Flywheel** (you are here)  
-> • [A Freemium Model Owners Trust](#a-freemium-model-owners-trust)  
-> • [Roadmap & Next Steps](#roadmap--next-steps)
+> • [A Freemium Model Owners Trust](../price/)  
+> • [Roadmap & Next Steps](../next/)
 
 ---
 

--- a/maps/index.md
+++ b/maps/index.md
@@ -10,9 +10,10 @@
    4.2. [Owner-Curated Overlay for Maps](#owner-curated-overlay-for-maps)  
    4.3. [AI-Generated “Instant Sites”](#ai-generated-instant-sites)  
 5. [Cross-Business Promotion & Dynamic Offers](#cross-business-promotion--dynamic-offers)  
-6. [Business Model & Pricing](#business-model--pricing)  
-7. [Benefits by Stakeholder](#benefits-by-stakeholder)  
+6. [Business Model & Pricing](#business-model--pricing)
+7. [Benefits by Stakeholder](#benefits-by-stakeholder)
 8. [Future Enhancements](#future-enhancements)
+9. [Sub-Articles in This Series](#sub-articles-in-this-series)
 
 ---
 
@@ -203,8 +204,23 @@
 ## 8. Future Enhancements
 - **Integrated payments/deposits**  
 - **Analytics dashboard** (traffic, conversions, ROI)  
-- **Social sync**: auto-post specials to TikTok/IG  
-- **AI review spam filter**  
+- **Social sync**: auto-post specials to TikTok/IG
+- **AI review spam filter**
 - **Multi-location chains API**
 
 ---
+
+## 9. Sub-Articles in This Series
+- [Do You Really Need a Website?](why/)
+- [Taming the Google Maps Wild West](wild/)
+- [Where Bad Sites Come From](when/)
+- [PDF Menus → Microsites](pdf/)
+- [Time-Slot Deals for Any Business](time/)
+- [AI-Generated Instant Sites](ai/)
+- [Curating Google Maps Listings](curate/)
+- [The Microsite Flywheel](fly/)
+- [A Freemium Model Owners Trust](price/)
+- [Roadmap & Next Steps](next/)
+
+---
+ 

--- a/maps/next/index.md
+++ b/maps/next/index.md
@@ -1,16 +1,17 @@
 # Roadmap & Next Steps  
 *Where the Google-Maps-first platform is heading from 2025 to 2027—and why it matters to owners, partners, and users.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [Where Bad Sites Come From](#where-bad-sites-come-from)  
-> • [PDF Menus → Microsites](#pdf-menus-→-microsites)  
-> • [Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)  
-> • [AI-Generated Instant Sites](#ai-generated-instant-sites)  
-> • [Curating Google Maps Listings](#curating-google-maps-listings)  
-> • [The Microsite Flywheel](#the-microsite-flywheel)  
-> • [A Freemium Model Owners Trust](#a-freemium-model-owners-trust)  
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)  
+> • [Time-Slot Deals for Any Business](../time/)  
+> • [AI-Generated Instant Sites](../ai/)  
+> • [Curating Google Maps Listings](../curate/)  
+> • [The Microsite Flywheel](../fly/)  
+> • [A Freemium Model Owners Trust](../price/)  
 > • **Roadmap & Next Steps** (you are here)
 
 ---

--- a/maps/pdf/index.md
+++ b/maps/pdf/index.md
@@ -1,17 +1,18 @@
 # PDF Menus → Microsites  
 *How restaurants evolved from printed lists to dynamic, mobile-first experiences.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [Where Bad Sites Come From](#where-bad-sites-come-from)  
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
 > • **PDF Menus → Microsites** (you are here)  
-> • [Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)  
-> • [AI-Generated Instant Sites](#ai-generated-instant-sites)  
-> • [Curating Google Maps Listings](#curating-google-maps-listings)  
-> • [The Microsite Flywheel](#the-microsite-flywheel)  
-> • [A Freemium Model Owners Trust](#a-freemium-model-owners-trust)  
-> • [Roadmap & Next Steps](#roadmap--next-steps)
+> • [Time-Slot Deals for Any Business](../time/)  
+> • [AI-Generated Instant Sites](../ai/)  
+> • [Curating Google Maps Listings](../curate/)  
+> • [The Microsite Flywheel](../fly/)  
+> • [A Freemium Model Owners Trust](../price/)  
+> • [Roadmap & Next Steps](../next/)
 
 ---
 
@@ -28,7 +29,7 @@
 </tbody>
 </table>
 
-For the broader “site or no site” debate, start with *[Do You Really Need a Website?](#do-you-really-need-a-website)*.
+For the broader “site or no site” debate, start with *[Do You Really Need a Website?](../why/)*.
 
 ---
 
@@ -37,7 +38,7 @@ For the broader “site or no site” debate, start with *[Do You Really Need a 
 - **Problems:** Zero accessibility, no update path, killed by iPhone (no Flash).  
 - **Lesson:** Fancy tech ages fast; content flexibility matters more.  
 
-This legacy still haunts many eateries—see *[Where Bad Sites Come From](#where-bad-sites-come-from)*.
+This legacy still haunts many eateries—see *[Where Bad Sites Come From](../when/)*.
 
 ---
 
@@ -52,7 +53,7 @@ This legacy still haunts many eateries—see *[Where Bad Sites Come From](#where
 - 3–8 MB files on 4G = **7-second loads**.  
 - No structured data → Google “Menu” panel stays empty.
 
-The PDF pattern is still rampant; we dissect its pitfalls in *[Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)*.
+The PDF pattern is still rampant; we dissect its pitfalls in *[Taming the Google Maps Wild West](../wild/)*.
 
 ---
 
@@ -62,7 +63,7 @@ The PDF pattern is still rampant; we dissect its pitfalls in *[Taming the Google
 - **Cons:** 25–35 % commission, loss of branding, data silos.  
 - Many restaurants simply linked their Maps website button to *their* page on an aggregator—effectively **outsourcing the homepage**.
 
-Cross-industry discount mechanics are explored in *[Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)*.
+Cross-industry discount mechanics are explored in *[Time-Slot Deals for Any Business](../time/)*.
 
 ---
 
@@ -71,7 +72,7 @@ Cross-industry discount mechanics are explored in *[Time-Slot Deals for Any Busi
 - But Maps shows **only fragments**: hours, location, crowd photos.  
 - Owners who rely on PDF links miss out on structured *Menu* panels, rich snippets, and in-list actions.
 
-How to polish that Maps listing? → *[Curating Google Maps Listings](#curating-google-maps-listings)*.
+How to polish that Maps listing? → *[Curating Google Maps Listings](../curate/)*.
 
 ---
 
@@ -90,7 +91,7 @@ A **single-page, mobile-first site** that extends the Maps listing with live dat
 | Live price edits | ✅ 1-click CMS | ❌ Re-export each time |
 | Load time (3 G) | **1–1.5 s** | 5-8 s |
 
-The easy-button way to get one is outlined in *[AI-Generated Instant Sites](#ai-generated-instant-sites)*.
+The easy-button way to get one is outlined in *[AI-Generated Instant Sites](../ai/)*.
 
 ---
 
@@ -101,13 +102,13 @@ The easy-button way to get one is outlined in *[AI-Generated Instant Sites](#ai-
    - Use semantic `<nav>`, `<section>`; embed `schema.org/Menu`.  
 2. **Site Builders (Modern)**  
    - Choose lightweight, mobile templates (<150 KB JS).  
-   - Beware “all-in-one” bloat—see *[Where Bad Sites Come From](#where-bad-sites-come-from)*.  
+   - Beware “all-in-one” bloat—see *[Where Bad Sites Come From](../when/)*.  
 3. **AI Auto-Generate** *(fastest)*  
    - Import items from PDF/Images → structured microsite in minutes.  
    - Part of our platform’s *Instant Site* flow.  
 4. **Overlay + Microsite Combo**  
    - Use overlay to clean Maps photos, microsite to host menu.  
-   - Workflow in *[Curating Google Maps Listings](#curating-google-maps-listings)*.
+   - Workflow in *[Curating Google Maps Listings](../curate/)*.
 
 ---
 
@@ -119,7 +120,7 @@ The easy-button way to get one is outlined in *[AI-Generated Instant Sites](#ai-
 | Online bookings / wk | 0 (call-only) | 34 | +34 |
 | Google “Menu” panel | Hidden | Auto-populated | — |
 
-Story continues in *[The Microsite Flywheel](#the-microsite-flywheel)*—how Casa Verde cross-promotes with nearby gelateria.
+Story continues in *[The Microsite Flywheel](../fly/)*—how Casa Verde cross-promotes with nearby gelateria.
 
 ---
 
@@ -127,7 +128,7 @@ Story continues in *[The Microsite Flywheel](#the-microsite-flywheel)*—how Cas
 
 1. **Locate the latest editable menu file** (Word, InDesign).  
 2. **Export items to CSV** (columns: title, description, price, dietary tags).  
-3. **Upload CSV to Instant-Site wizard** (*[AI-Generated Instant Sites](#ai-generated-instant-sites)*).  
+3. **Upload CSV to Instant-Site wizard** (*[AI-Generated Instant Sites](../ai/)*).  
 4. **Pick a template** (dark/light, hero image).  
 5. **Add booking widget** (optional).  
 6. **Swap Maps website URL** → new microsite.  
@@ -137,9 +138,9 @@ Story continues in *[The Microsite Flywheel](#the-microsite-flywheel)*—how Cas
 ---
 
 ## 10 | Monetization & Upkeep
-- **Free tier**: host up to 100 menu SKUs, 1 location badge—details in *[A Freemium Model Owners Trust](#a-freemium-model-owners-trust)*.  
+- **Free tier**: host up to 100 menu SKUs, 1 location badge—details in *[A Freemium Model Owners Trust](../price/)*.  
 - **Growth tier**: multi-language menus, advanced analytics, offline POS sync.  
-- **Pro tier**: headless API for kiosks, loyalty engine integration—roadmap in *[Roadmap & Next Steps](#roadmap--next-steps)*.
+- **Pro tier**: headless API for kiosks, loyalty engine integration—roadmap in *[Roadmap & Next Steps](../next/)*.
 
 ---
 
@@ -152,9 +153,9 @@ Story continues in *[The Microsite Flywheel](#the-microsite-flywheel)*—how Cas
 ---
 
 ## 12 | Next Reads
-- **[Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)** – Clean your listing before linking it.  
-- **[Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)** – Use off-peak discounts to drive table turns.  
-- **[The Microsite Flywheel](#the-microsite-flywheel)** – Leverage cross-business discovery once your page is live.
+- **[Taming the Google Maps Wild West](../wild/)** – Clean your listing before linking it.  
+- **[Time-Slot Deals for Any Business](../time/)** – Use off-peak discounts to drive table turns.  
+- **[The Microsite Flywheel](../fly/)** – Leverage cross-business discovery once your page is live.
 
 ---
 

--- a/maps/price/index.md
+++ b/maps/price/index.md
@@ -1,17 +1,18 @@
 # A Freemium Model Owners Trust  
 *Pricing, ethics, and upgrade cues for Google-Maps-first microsites.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [Where Bad Sites Come From](#where-bad-sites-come-from)  
-> • [PDF Menus → Microsites](#pdf-menus-→-microsites)  
-> • [Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)  
-> • [AI-Generated Instant Sites](#ai-generated-instant-sites)  
-> • [Curating Google Maps Listings](#curating-google-maps-listings)  
-> • [The Microsite Flywheel](#the-microsite-flywheel)  
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)  
+> • [Time-Slot Deals for Any Business](../time/)  
+> • [AI-Generated Instant Sites](../ai/)  
+> • [Curating Google Maps Listings](../curate/)  
+> • [The Microsite Flywheel](../fly/)  
 > • **A Freemium Model Owners Trust** (you are here)  
-> • [Roadmap & Next Steps](#roadmap--next-steps)
+> • [Roadmap & Next Steps](../next/)
 
 ---
 

--- a/maps/time/index.md
+++ b/maps/time/index.md
@@ -1,17 +1,18 @@
 # Time-Slot Deals for Any Business  
 *How off-peak discounts can fill empty chairs, exam rooms, and shelves—well beyond food service.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [Where Bad Sites Come From](#where-bad-sites-come-from)  
-> • [PDF Menus → Microsites](#pdf-menus-→-microsites)  
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)  
 > • **Time-Slot Deals for Any Business** (you are here)  
-> • [AI-Generated Instant Sites](#ai-generated-instant-sites)  
-> • [Curating Google Maps Listings](#curating-google-maps-listings)  
-> • [The Microsite Flywheel](#the-microsite-flywheel)  
-> • [A Freemium Model Owners Trust](#a-freemium-model-owners-trust)  
-> • [Roadmap & Next Steps](#roadmap--next-steps)
+> • [AI-Generated Instant Sites](../ai/)  
+> • [Curating Google Maps Listings](../curate/)  
+> • [The Microsite Flywheel](../fly/)  
+> • [A Freemium Model Owners Trust](../price/)  
+> • [Roadmap & Next Steps](../next/)
 
 ---
 
@@ -25,14 +26,14 @@ Restaurants use **The Fork** to sell tables at –30 % on quiet Tuesdays. Cafés
 | **Yoga Studios** | 6 pm after-work vs. mid-afternoon | Half-empty classes |
 | **Retail Boutiques** | Weekends vs. Mon/Tue | Stale seasonal stock |
 
-If you’re still wondering *whether you even need a web layer* to run these offers, hop to **[Do You Really Need a Website?](#do-you-really-need-a-website)** first.
+If you’re still wondering *whether you even need a web layer* to run these offers, hop to **[Do You Really Need a Website?](../why/)** first.
 
 ---
 
 ## 2 | Core Mechanics of a Time-Slot Deal Engine
 1. **Inventory Model** — Define a quantifiable slot (chair-hour, class seat, SKU batch).  
 2. **Dynamic Pricing** — X % off when predicted fill rate < target.  
-3. **Real-Time Publishing** — Push to Maps overlay + microsite banner (see **[Curating Google Maps Listings](#curating-google-maps-listings)**).  
+3. **Real-Time Publishing** — Push to Maps overlay + microsite banner (see **[Curating Google Maps Listings](../curate/)**).  
 4. **Auto-Expiry** — Deal disappears once slot is booked or window closes.  
 5. **Data Loop** — Track redemption, repeat rate, margin delta.
 
@@ -46,7 +47,7 @@ If you’re still wondering *whether you even need a web layer* to run these off
 - **Slot Definition:** 30-min haircut block.  
 - **Ideal Discount:** –15 % or free add-on (beard trim).  
 - **UX Flow:** Customer picks off-peak slot → pays deposit → calendar invite.  
-- **Common Pitfall:** Staff forgetting to update walk-in board—solve with instant POS sync (road-mapped under **[Roadmap & Next Steps](#roadmap--next-steps)**).
+- **Common Pitfall:** Staff forgetting to update walk-in board—solve with instant POS sync (road-mapped under **[Roadmap & Next Steps](../next/)**).
 
 ### 3.2 Dental & Medical
 - **Compliance Watch:** Must display pre-discount fee transparently.  
@@ -59,7 +60,7 @@ If you’re still wondering *whether you even need a web layer* to run these off
 
 ### 3.4 Gyms & Studios
 - **Class Fill Rate:** Auto-drop single-class price 2 h before if <60 % booked.  
-- **Upsell Path:** Convert trial to monthly membership (looped into **[The Microsite Flywheel](#the-microsite-flywheel)**).
+- **Upsell Path:** Convert trial to monthly membership (looped into **[The Microsite Flywheel](../fly/)**).
 
 ---
 
@@ -70,7 +71,7 @@ If you’re still wondering *whether you even need a web layer* to run these off
 | **Pricing Engine** | Rule-based (phase 1) → ML demand curve (phase 2) | A/B test discount depths |
 | **Surface** | Maps overlay banner + microsite sticky CTA | <1 s cache invalidation |
 | **Booking / Cart** | Stripe Checkout or in-house payment sheet | Deposit option |
-| **Notifications** | Email + push via PWA (“Add to Home Screen” from **[PDF Menus → Microsites](#pdf-menus-→-microsites)**) | 1-click Apple Wallet pass |
+| **Notifications** | Email + push via PWA (“Add to Home Screen” from **[PDF Menus → Microsites](../pdf/)**) | 1-click Apple Wallet pass |
 
 ---
 
@@ -92,9 +93,9 @@ The lifetime value of those new customers then compounds—captured in your **Mi
 
 1. **Map Empty Slots** — Export POS/booking data; label <60 % fill windows.  
 2. **Choose Incentive** — %-off, add-on, or loyalty-points boost.  
-3. **Build Offer Templates** — Via dashboard (Free tier allows 3; limits explained in **[A Freemium Model Owners Trust](#a-freemium-model-owners-trust)**).  
-4. **Generate Microsite Section** — Use **[AI-Generated Instant Sites](#ai-generated-instant-sites)** wizard; auto-sync slots.  
-5. **Activate Overlay Banner** — Push to Google Maps listing (see **[Curating Google Maps Listings](#curating-google-maps-listings)**).  
+3. **Build Offer Templates** — Via dashboard (Free tier allows 3; limits explained in **[A Freemium Model Owners Trust](../price/)**).  
+4. **Generate Microsite Section** — Use **[AI-Generated Instant Sites](../ai/)** wizard; auto-sync slots.  
+5. **Activate Overlay Banner** — Push to Google Maps listing (see **[Curating Google Maps Listings](../curate/)**).  
 6. **Pilot 1 Week** — Track impressions → bookings → no-shows.  
 7. **Iterate** — Adjust discount depth; enable auto-pricing rules.  
 
@@ -114,9 +115,9 @@ F --> G(Auto-prompt for review)
 
 | Business | Pre-Pilot Pain | 30-Day Outcome | Related Deep-Dive |
 |----------|---------------|----------------|-------------------|
-| **ClipJoint Barbers** | Tuesday/Wednesday lull | +48 weekday bookings | *See* “[Where Bad Sites Come From](#where-bad-sites-come-from)” §5.1 |
-| **SmileBright Dental** | Empty hygiene slots 8-10 am | Chair utilisation **62 % → 91 %** | *See* “[Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)” (photo clean-up boosted reach) |
-| **Luna Boutique** | Post-season dead stock | Cleared 70 % via flash slots | *See* “[The Microsite Flywheel](#the-microsite-flywheel)” (cross-promo with neighbouring café) |
+| **ClipJoint Barbers** | Tuesday/Wednesday lull | +48 weekday bookings | *See* “[Where Bad Sites Come From](../when/)” §5.1 |
+| **SmileBright Dental** | Empty hygiene slots 8-10 am | Chair utilisation **62 % → 91 %** | *See* “[Taming the Google Maps Wild West](../wild/)” (photo clean-up boosted reach) |
+| **Luna Boutique** | Post-season dead stock | Cleared 70 % via flash slots | *See* “[The Microsite Flywheel](../fly/)” (cross-promo with neighbouring café) |
 
 ---
 
@@ -143,7 +144,7 @@ F --> G(Auto-prompt for review)
 
 1. **Dynamic Bundles** – Pair a slow-hour massage with a neighbouring café’s pastry voucher.  
 2. **Surge *Premium* Pricing** – Flip the model: raise prices for peak-demand slots.  
-3. **AI Demand Forecasting** – Pull weather/event data to pre-set discounts (slated in “[Roadmap & Next Steps](#roadmap--next-steps)”).  
+3. **AI Demand Forecasting** – Pull weather/event data to pre-set discounts (slated in “[Roadmap & Next Steps](../next/)”).  
 
 ---
 
@@ -158,9 +159,9 @@ F --> G(Auto-prompt for review)
 
 ## 13 | Next Reads
 
-* **[AI-Generated Instant Sites](#ai-generated-instant-sites)** – Fastest way to host your deal engine.  
-* **[Curating Google Maps Listings](#curating-google-maps-listings)** – Make your banner pop amid clean photos.  
-* **[A Freemium Model Owners Trust](#a-freemium-model-owners-trust)** – Understand slot limits and upgrade paths.
+* **[AI-Generated Instant Sites](../ai/)** – Fastest way to host your deal engine.  
+* **[Curating Google Maps Listings](../curate/)** – Make your banner pop amid clean photos.  
+* **[A Freemium Model Owners Trust](../price/)** – Understand slot limits and upgrade paths.
 
 ---
 

--- a/maps/when/index.md
+++ b/maps/when/index.md
@@ -1,16 +1,18 @@
 # Where Bad Sites Come From  
 *Tracing the root causes of ugly, slow, and useless local-business websites—so you can avoid them.*
 
-> **Part of the series:**  
-> • [Do You Really Need a Website?](#do-you-really-need-a-website)  
-> • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)  
-> • [PDF Menus → Microsites](#pdf-menus-→-microsites)  
-> • [AI-Generated Instant Sites](#ai-generated-instant-sites)  
-> • [Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)  
-> • [Curating Google Maps Listings](#curating-google-maps-listings)  
-> • [The Microsite Flywheel](#the-microsite-flywheel)  
-> • [A Freemium Model Owners Trust](#a-freemium-model-owners-trust)  
-> • [Roadmap & Next Steps](#roadmap--next-steps)
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • [Taming the Google Maps Wild West](../wild/)
+> • **Where Bad Sites Come From** (you are here)
+> • [PDF Menus → Microsites](../pdf/)
+> • [AI-Generated Instant Sites](../ai/)
+> • [Time-Slot Deals for Any Business](../time/)
+> • [Curating Google Maps Listings](../curate/)
+> • [The Microsite Flywheel](../fly/)
+> • [A Freemium Model Owners Trust](../price/)
+> • [Roadmap & Next Steps](../next/)
 
 ---
 
@@ -19,7 +21,7 @@
 - **Yet** those same businesses keep commissioning (or ignoring) them.  
 - **Result:** a web littered with autoplay music, PDF menus, and 1999 design vibes.
 
-If you’re asking whether you need a site at all, start with *[Do You Really Need a Website?](#do-you-really-need-a-website)*; this article assumes you’ve said “yes—something.”
+If you’re asking whether you need a site at all, start with *[Do You Really Need a Website?](../why/)*; this article assumes you’ve said “yes—something.”
 
 ---
 
@@ -32,7 +34,7 @@ If you’re asking whether you need a site at all, start with *[Do You Really Ne
 | **Local “Friend Who Codes”** | Pizza & thanks | “Mate will sort it” | Hobby code, no backups, single-point failure |
 | **Small Digital Agencies** | €2–5 k build + €50 / mo | “Professional look” | Lock-in hosting, upsell treadmill, slow change requests |
 
-For the historic angle on restaurants specifically, see *[PDF Menus → Microsites](#pdf-menus-→-microsites)*.
+For the historic angle on restaurants specifically, see *[PDF Menus → Microsites](../pdf/)*.
 
 ---
 
@@ -59,7 +61,7 @@ For the historic angle on restaurants specifically, see *[PDF Menus → Microsit
 - Proprietary CMS = leaving means rebuilding from scratch.  
 - Relies on heavy plugins (sliders, analytics) → performance drag.
 
-See how an owner-curated overlay can complement or replace these in *[Curating Google Maps Listings](#curating-google-maps-listings)*.
+See how an owner-curated overlay can complement or replace these in *[Curating Google Maps Listings](../curate/)*.
 
 ---
 
@@ -74,7 +76,7 @@ See how an owner-curated overlay can complement or replace these in *[Curating G
 | **SSL & Privacy** | HTTPS, cookies banner | “Not Secure” badge |
 | **Booking / Contact Flow** | ≤ 3 taps | Mailto: link only |
 
-Add these into your quarterly audit calendar; see *[A Freemium Model Owners Trust](#a-freemium-model-owners-trust)* for automated reminders.
+Add these into your quarterly audit calendar; see *[A Freemium Model Owners Trust](../price/)* for automated reminders.
 
 ---
 
@@ -83,13 +85,13 @@ Add these into your quarterly audit calendar; see *[A Freemium Model Owners Trus
 ### 5.1 “Beard & Brew Barbers”
 - **Source**: Friend-coder (React SPA).  
 - **Issue**: 4 MB bundle, fails on older Android.  
-- **Fix**: Swapped to microsite + *[Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)* widget.  
+- **Fix**: Swapped to microsite + *[Time-Slot Deals for Any Business](../time/)* widget.  
 - **Outcome**: 28 % lift in weekday seats.
 
 ### 5.2 “La Nonna Pizzeria”
 - **Source**: Upwork WordPress theme.  
 - **Issue**: Menu as JPEG; no alt text; CLS warnings.  
-- **Fix**: AI-generated instant site (see *[AI-Generated Instant Sites](#ai-generated-instant-sites)*).  
+- **Fix**: AI-generated instant site (see *[AI-Generated Instant Sites](../ai/)*).  
 - **Outcome**: PageSpeed 92 → 99; online orders +17 %.
 
 ### 5.3 “Bloom Boutique Hotel”
@@ -109,7 +111,7 @@ Add these into your quarterly audit calendar; see *[A Freemium Model Owners Trus
 | **Can’t edit, friend vanished** | — | — | ✅ (instant site) |
 | **Agency lock-in, high fees** | — | ✅ (overlay + gradual migration) | → Evaluate |
 
-Overlay concept detailed in *[Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)*.
+Overlay concept detailed in *[Taming the Google Maps Wild West](../wild/)*.
 
 ---
 
@@ -118,7 +120,7 @@ Overlay concept detailed in *[Taming the Google Maps Wild West](#taming-the-goog
 1. **Audit** with the 6-point test.  
 2. If < 3 fails → quick overlay & microsite.  
 3. If 3+ fails → generate new site with AI pipeline.  
-4. Integrate upsell hooks via *[The Microsite Flywheel](#the-microsite-flywheel)* for long-term growth.
+4. Integrate upsell hooks via *[The Microsite Flywheel](../fly/)* for long-term growth.
 
 ---
 
@@ -131,7 +133,7 @@ Overlay concept detailed in *[Taming the Google Maps Wild West](#taming-the-goog
 | **Performance Budgets** | Max 150 KB CSS + JS per page |
 | **Owner Training** | 15-min video onboarding; ongoing tooltips |
 
-Our roadmap adds live **Performance Score alerts**—see *[Roadmap & Next Steps](#roadmap--next-steps)*.
+Our roadmap adds live **Performance Score alerts**—see *[Roadmap & Next Steps](../next/)*.
 
 ---
 
@@ -144,9 +146,9 @@ Our roadmap adds live **Performance Score alerts**—see *[Roadmap & Next Steps]
 ---
 
 ## 10 | Next Reads
-- **[Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)** – Fix your listing before fixing your site.  
-- **[AI-Generated Instant Sites](#ai-generated-instant-sites)** – See a new site spin up in minutes.  
-- **[A Freemium Model Owners Trust](#a-freemium-model-owners-trust)** – Understand the cost path.
+- **[Taming the Google Maps Wild West](../wild/)** – Fix your listing before fixing your site.  
+- **[AI-Generated Instant Sites](../ai/)** – See a new site spin up in minutes.  
+- **[A Freemium Model Owners Trust](../price/)** – Understand the cost path.
 
 ---
 

--- a/maps/why/index.md
+++ b/maps/why/index.md
@@ -1,7 +1,18 @@
-# Do You Really Need a Website?  
+# Do You Really Need a Website?
 *A reality-check for cafés, barbers, bakeries & every other “Google-Maps-first” business.*
 
-> **Part of the series:** [Context & Core Concept](#context--core-concept) • [Taming the Google Maps Wild West](#taming-the-google-maps-wild-west) • [PDF Menus → Microsites](#pdf-menus-→-microsites) • [AI-Generated Instant Sites](#ai-generated-instant-sites)
+> **Part of the series:**
+> • [Overview](../)
+> • **Do You Really Need a Website?** (you are here)
+> • [Taming the Google Maps Wild West](../wild/)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)
+> • [Time-Slot Deals for Any Business](../time/)
+> • [AI-Generated Instant Sites](../ai/)
+> • [Curating Google Maps Listings](../curate/)
+> • [The Microsite Flywheel](../fly/)
+> • [A Freemium Model Owners Trust](../price/)
+> • [Roadmap & Next Steps](../next/)
 
 ---
 
@@ -28,7 +39,7 @@ Reality:
 | Time-slot booking | ❌ (unless 3rd-party integrated) | No-shows & lost revenue |
 | The owner’s “story” | ❌ Buried in crowdsourced reviews | Brand dilution |
 
-For a deep dive into that chaos, read **[Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)**.
+For a deep dive into that chaos, read **[Taming the Google Maps Wild West](../wild/)**.
 
 ---
 
@@ -37,7 +48,7 @@ For a deep dive into that chaos, read **[Taming the Google Maps Wild West](#tami
 ### 3.1. PDF & Google-Doc Menus  
 - **Pros:** fast, printable, free.  
 - **Cons:** non-indexed by search, zero analytics, awkward on phones.  
-- See how restaurants evolved in **[PDF Menus → Microsites](#pdf-menus-→-microsites)**.
+- See how restaurants evolved in **[PDF Menus → Microsites](../pdf/)**.
 
 ### 3.2. DIY Builders (Wix, Jimdo)  
 - **Pros:** cheap starter templates.  
@@ -70,14 +81,14 @@ A one-page site that:
 3. Can be **added to the home screen** like an app.  
 4. Costs almost nothing to maintain.
 
-See how we auto-generate one in **[AI-Generated Instant Sites](#ai-generated-instant-sites)**.
+See how we auto-generate one in **[AI-Generated Instant Sites](../ai/)**.
 
 ---
 
 ## 6. Decision Checklist
 
 - [ ] Has my Maps listing converted < 2 % of profile views into visits last month?  
-- [ ] Do I rely on time-slot utilization (e.g., off-peak barber seats)? => Pair with **[Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)**.  
+- [ ] Do I rely on time-slot utilization (e.g., off-peak barber seats)? => Pair with **[Time-Slot Deals for Any Business](../time/)**.  
 - [ ] Is my “website” currently a PDF?  
 - [ ] Am I paying $$ for a site I never update?  
 
@@ -87,9 +98,9 @@ If you tick one or more boxes, **start with a microsite** and grow only when the
 
 ## 7. Next Reads in the Series
 
-1. **[Taming the Google Maps Wild West](#taming-the-google-maps-wild-west)** – Clean up crowdsourced chaos.  
-2. **[AI-Generated Instant Sites](#ai-generated-instant-sites)** – See the no-code build flow.  
-3. **[A Freemium Model Owners Trust](#a-freemium-model-owners-trust)** – How we keep the base tier free & ad-free.
+1. **[Taming the Google Maps Wild West](../wild/)** – Clean up crowdsourced chaos.  
+2. **[AI-Generated Instant Sites](../ai/)** – See the no-code build flow.  
+3. **[A Freemium Model Owners Trust](../price/)** – How we keep the base tier free & ad-free.
 
 ---
 

--- a/maps/wild/index.md
+++ b/maps/wild/index.md
@@ -1,7 +1,18 @@
-# Taming the Google Maps Wild West  
+# Taming the Google Maps Wild West
 *How to wrest control of your listing—and turn chaos into conversions.*
 
-> **Part of the series:** [Do You Really Need a Website?](#do-you-really-need-a-website) • [Where Bad Sites Come From](#where-bad-sites-come-from) • [PDF Menus → Microsites](#pdf-menus-→-microsites) • [AI-Generated Instant Sites](#ai-generated-instant-sites)
+> **Part of the series:**
+> • [Overview](../)
+> • [Do You Really Need a Website?](../why/)
+> • **Taming the Google Maps Wild West** (you are here)
+> • [Where Bad Sites Come From](../when/)
+> • [PDF Menus → Microsites](../pdf/)
+> • [Time-Slot Deals for Any Business](../time/)
+> • [AI-Generated Instant Sites](../ai/)
+> • [Curating Google Maps Listings](../curate/)
+> • [The Microsite Flywheel](../fly/)
+> • [A Freemium Model Owners Trust](../price/)
+> • [Roadmap & Next Steps](../next/)
 
 ---
 
@@ -10,7 +21,7 @@
 - **Crowdsourced downside:** Anyone can add photos, reviews, or edits—useful, but often messy.  
 - **Business impact:** Out-of-date or irrelevant content lowers trust and click-through rates by up to **25 %** compared with a clean listing (internal benchmark, 2025Q1).  
 
-For a broader look at the “do I even need a site?” debate, see **[Do You Really Need a Website?](#do-you-really-need-a-website)**.
+For a broader look at the “do I even need a site?” debate, see **[Do You Really Need a Website?](../why/)**.
 
 ---
 
@@ -33,7 +44,7 @@ Google calls this “community-driven accuracy,” but in practice it’s the **
 | 3 | **Legacy reviews** | 1-star complaints about *previous* owners | Unfair rating average |
 | 4 | **Duplicate/defunct pins** | Old address never deleted | Navigation errors |
 
-Get a historical view of restaurant web pain in **[PDF Menus → Microsites](#pdf-menus-→-microsites)**.
+Get a historical view of restaurant web pain in **[PDF Menus → Microsites](../pdf/)**.
 
 ---
 
@@ -42,7 +53,7 @@ Get a historical view of restaurant web pain in **[PDF Menus → Microsites](#pd
 - **Visit intent:** When top review is > 5 years old, intent to visit falls **12 %** (survey, n = 438).  
 - **Bounce-back risk:** Users who click *away* after bad info rarely return—an invisible churn.
 
-Curious why owners still accept broken sites? Read **[Where Bad Sites Come From](#where-bad-sites-come-from)**.
+Curious why owners still accept broken sites? Read **[Where Bad Sites Come From](../when/)**.
 
 ---
 
@@ -64,10 +75,10 @@ Our platform adds a **light overlay** on top of Maps data:
 
 * **Pinned gallery**—choose 5 “hero” images that always appear first.  
 * **Featured reviews**—highlight recent, relevant stories.  
-* **Dynamic info bar**—live specials, time-slot discounts (ties into **[Time-Slot Deals for Any Business](#time-slot-deals-for-any-business)**).  
+* **Dynamic info bar**—live specials, time-slot discounts (ties into **[Time-Slot Deals for Any Business](../time/)**).  
 * **Cleanup AI**—auto-flags off-topic or low-quality photos.
 
-For the tech deep dive, see **[Curating Google Maps Listings](#curating-google-maps-listings)**.
+For the tech deep dive, see **[Curating Google Maps Listings](../curate/)**.
 
 ---
 
@@ -78,14 +89,14 @@ For the tech deep dive, see **[Curating Google Maps Listings](#curating-google-m
 4. **Answer Q&A**: Pin an owner response to top 3 recurring questions.  
 5. **Add menu link**: Even a PDF is better than nothing—until you upgrade to a microsite.
 
-When you’re ready to leap past PDFs, explore **[AI-Generated Instant Sites](#ai-generated-instant-sites)**.
+When you’re ready to leap past PDFs, explore **[AI-Generated Instant Sites](../ai/)**.
 
 ---
 
 ## 8. Turning Chaos into Marketing Fuel
 - **User photo contests**: Encourage patrons to post specific shots (e.g., “Latte Art of the Month”).  
 - **Review harvesting**: Pull top quotes into your microsite carousel—drives social proof.  
-- **Before/After stories**: Show transformation after your clean-up, and share in the **[Microsite Flywheel](#the-microsite-flywheel)** marketplace.
+- **Before/After stories**: Show transformation after your clean-up, and share in the **[Microsite Flywheel](../fly/)** marketplace.
 
 ---
 
@@ -98,14 +109,14 @@ When you’re ready to leap past PDFs, explore **[AI-Generated Instant Sites](#a
 | Update specials & time slots | Daily (auto) | Platform rules | Dynamic info bar |
 | Deep content audit | Quarterly | Owner | Checklist doc |
 
-Tip: build these into a recurring reminder—see **[A Freemium Model Owners Trust](#a-freemium-model-owners-trust)** for why the *Free* tier still includes basic reminders.
+Tip: build these into a recurring reminder—see **[A Freemium Model Owners Trust](../price/)** for why the *Free* tier still includes basic reminders.
 
 ---
 
 ## 10. What’s Next?
-1. **[AI-Generated Instant Sites](#ai-generated-instant-sites)** – Turn your cleaned listing into a full mobile microsite.  
-2. **[Do You Really Need a Website?](#do-you-really-need-a-website)** – Decide if a microsite is enough.  
-3. **[Roadmap & Next Steps](#roadmap--next-steps)** – Peek at payments, analytics, and multi-location APIs.
+1. **[AI-Generated Instant Sites](../ai/)** – Turn your cleaned listing into a full mobile microsite.  
+2. **[Do You Really Need a Website?](../why/)** – Decide if a microsite is enough.  
+3. **[Roadmap & Next Steps](../next/)** – Peek at payments, analytics, and multi-location APIs.
 
 ---
 


### PR DESCRIPTION
## Summary
- list all maps sub-articles in the overview and table of contents
- link each sub-article back to the overview and fix cross-links between pages

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx markdownlint '**/*.md'` *(fails: 403 Forbidden fetching package)*

------
https://chatgpt.com/codex/tasks/task_e_688f0b1978288322bc3feb3cca89e916