### PR TITLE
Expand article previews on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,13 +2,43 @@
 
 This is the home page of my simple static website. Navigate through the pages to learn more.
 
-- [Contact](/contact/index.md) – Offers ways to reach the author via GitHub issues or email for questions and collaboration.
-- [Personal Virtual Embassy](/personal_virtual_embassy/index.md) – Proposes an AI ambassador that retains context, adapts tone, and negotiates small tasks within user-defined boundaries.
-- [Gourmet vending](/gourmet/index.md) – Suggests standardized smart meal pods with encoded cook profiles and ovens that automatically prepare quality frozen meals.
-- [AEROLINK](/aerolink/index.md) – Introduces a modular cable-guided pod network linking sky lobbies to create a scalable 3D transit mesh for cities.
-- [Fly in cloud](/fly/index.md) – Reimagines aircraft cabins with inflatable, body-conforming pods that adapt to posture and enable flexible travel experiences.
-- [Echo Board](/echo/index.md) – Envisions a mobile keyboard that toggles between classic typing and an AI voice mode with gesture-driven controls.
-- [Ambient Audio](/ambient/index.md) – Describes a tactile device with tuning and presence wheels for low-pressure, always-on voice connections with loved ones.
-- [Tribe To Fly](/tribe-to-fly/index.md) – Explores forming temporary travel crews who match by vibe, pool funds, and book shared stays for richer adventures.
-- [Maps Websites](/maps/index.md)
-- [About](/about/index.md)
+## [Contact](/contact/index.md)
+Offers ways to reach the author via GitHub issues or email for questions and collaboration. Get in touch easily for feedback or project ideas.
+[Go to full text →](/contact/index.md)
+
+## [Personal Virtual Embassy](/personal_virtual_embassy/index.md)
+Proposes an AI ambassador that retains context, adapts tone, and negotiates small tasks within user-defined boundaries. It outlines how a virtual representative can manage tasks and communicate on your behalf.
+[Go to full text →](/personal_virtual_embassy/index.md)
+
+## [Gourmet vending](/gourmet/index.md)
+Suggests standardized smart meal pods with encoded cook profiles and ovens that automatically prepare quality frozen meals. This concept aims to provide quick and consistent gourmet dining experiences at home or on the go.
+[Go to full text →](/gourmet/index.md)
+
+## [AEROLINK](/aerolink/index.md)
+Introduces a modular cable-guided pod network linking sky lobbies to create a scalable 3D transit mesh for cities. The system envisions reducing ground congestion through elevated travel.
+[Go to full text →](/aerolink/index.md)
+
+## [Fly in cloud](/fly/index.md)
+Reimagines aircraft cabins with inflatable, body-conforming pods that adapt to posture and enable flexible travel experiences. The idea prioritizes passenger comfort and configurable layouts.
+[Go to full text →](/fly/index.md)
+
+## [Echo Board](/echo/index.md)
+Envisions a mobile keyboard that toggles between classic typing and an AI voice mode with gesture-driven controls. The design blends tactile feedback with voice interaction for versatile communication.
+[Go to full text →](/echo/index.md)
+
+## [Ambient Audio](/ambient/index.md)
+Describes a tactile device with tuning and presence wheels for low-pressure, always-on voice connections with loved ones. It seeks to foster gentle, ambient communication that feels natural.
+[Go to full text →](/ambient/index.md)
+
+## [Tribe To Fly](/tribe-to-fly/index.md)
+Explores forming temporary travel crews who match by vibe, pool funds, and book shared stays for richer adventures. By coordinating as a group, travelers can discover new places and build lasting connections.
+[Go to full text →](/tribe-to-fly/index.md)
+
+## [Maps Websites](/maps/index.md)
+A collection of ideas on creating better map-focused sites for local businesses. Discover research, solutions, and a full series of sub-articles.
+[Go to full text →](/maps/index.md)
+
+## [About](/about/index.md)
+Learn more about the purpose of this site and the ideas behind it.
+[Go to full text →](/about/index.md)
+


### PR DESCRIPTION
## Summary
- restyle homepage article list using larger headings and descriptive paragraphs
- make each title and a trailing "Go to full text" link clickable to its article
- add missing description for "Maps Websites" section

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f0f90007083229aed5a855d1fff96