### PR TITLE
Add GitHub Pages configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+title: "Ideas Home"
+description: >-
+  A loose collection of independent concepts across mobility, food tech,
+  ambient communication, and more.
+baseurl: ""
+# Set the theme so the site title appears as a return link on each page
+# (GitHub Pages will use this theme by default)
+theme: jekyll-theme-minimal


### PR DESCRIPTION
## Summary
- Define site metadata for GitHub Pages with readable title and description
- Specify minimal theme so title appears as a return link across pages

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_688f2159aec8832290fb99b8b7951120