### PR TITLE
Add calendar article and home page link

### DIFF
--- a/calendar/index.md
+++ b/calendar/index.md
@@ -1,0 +1,49 @@
+---
+title: Planning Your City Adventure—An AI-Driven, Community-Powered Approach
+---
+
+# Planning Your City Adventure—An AI-Driven, Community-Powered Approach
+
+Welcome to the future of event planning! In a world of fragmented calendars and endless online feeds, our app brings everything together in one simple, user-friendly experience. We start with a calendar you’ll actually love, powered by community contributions and intelligent AI, all designed to get you **out** of your phone and **into** the real world.
+
+This overview introduces the core vision and links to nine deep-dive articles that explore each piece of the puzzle in detail.
+
+---
+
+## 📑 Series Contents
+
+1. [Who We’re Building For: Traveler & After-Work Explorer Personas](./personas/)
+   Discover the two primary user groups—weekend hosts showing friends around and busy office workers seeking post-work plans. We’ll unpack their motivations, pain points, and decision-making processes, complete with day-in-the-life user journeys and illustrative scenarios.
+
+2. [A Calendar You’ll Actually Love: Designing the Calendar-First UI](./calendar-ui/)
+   Dive into our simplified, zoomable calendar interface that balances a high-level overview with detailed daily views. This article includes wireframes, interaction patterns (swipe cards, tile grids, story-style snippets), and the UX principles guiding each design choice.
+
+3. [Mood as Your Map: From “Relaxed” to “Energized”](./moods/)
+   Learn how we translate a warm-to-cool spectrum of moods—relaxation, exploration, focus, activity—into a visual heat-map that shows your month at a glance. We’ll cover color mappings, mood category definitions, and examples of how this guides healthier, more balanced planning.
+
+4. [Inbox → Insight: Email Forwarding & LLM-Powered Event Extraction](./email-llm/)
+   See how a simple “forward-to-service” workflow turns event emails into structured calendar suggestions while preserving privacy. You’ll get a behind-the-scenes look at our LLM parsing pipeline, schema mapping (title, time, venue, category, image), and before/after email samples.
+
+5. [Building the World’s Event Wiki: Community Contributions & Curation](./community/)
+   Explore our wiki-style repository model where users, bloggers, and moderators collaborate to keep event data fresh and accurate. We’ll detail contributor roles, moderation tools, upvote/rating mechanics, and gamification elements like badges and “trusted source” flags.
+
+6. [Smart Suggestions: Personalization & Chained Event Recommendations](./smart-suggestions/)
+   Unpack the algorithms behind our location-aware, behavior-driven ranking system. From filtering by popularity and past interest to chaining sequences (e.g., drinks → concert → late-night stroll), we’ll illustrate real user flows and the data signals that power each suggestion.
+
+7. [Staying Out, Not Stuck In: Integrations & Non-Intrusive Reminders](./integrations/)
+   Learn how one-tap exports to Google/Apple Calendars and “only when it matters” alerts (cancellations, time changes) keep you on schedule without cluttering your screen. We’ll share integration workflows, API considerations, and UX mockups for light-touch reminders.
+
+8. [Money Moves & Future Features: Ticket Sales, Exchanges & Beyond](./ticketing/)
+   Map out our monetization roadmap—from affiliate ticket sales to a community-driven exchange platform inspired by TicketSwap. This piece will cover potential partnership models, secure transaction frameworks, and a timeline for in-app ticketing and user-created events.
+
+9. [Where We Stand: Market Landscape & Competitive Analysis](./market-analysis/)
+   Survey the current ecosystem—Google/Apple Calendars, Facebook Events, Meetup, Resident Advisor—and pinpoint our unique value proposition. We’ll present competitor feature matrices, SWOT insights, market sizing, and go-to-market strategies tailored by region.
+
+---
+
+> **Next Steps**  
+> 1. Choose a sub-article to explore first—personas and market analysis often provide a solid foundation.  
+> 2. Click the links above to dive into each topic.  
+> 3. Share feedback or questions as you go; this roadmap is iterative, and your insights will shape the journey!
+
+Happy planning, and here’s to getting outside and touching some grass! 🌿

--- a/index.md
+++ b/index.md
@@ -41,6 +41,11 @@ A collection of ideas on creating better map-focused sites for local businesses.
 
 [Go to full text →](/maps/index.md)
 
+## Planning Your City Adventure—An AI-Driven, Community-Powered Approach
+An overview of a community-fed, AI-enhanced calendar that links nine deep-dive articles to help you plan richer outings.
+
+[Go to full text →](/calendar/index.md)
+
 ## [Contact](/contact/index.md)
 
 ## [About](/about/index.md)


### PR DESCRIPTION
## Summary
- add "Planning Your City Adventure—An AI-Driven, Community-Powered Approach" article under new `calendar` section
- list the calendar article on the home page with a short summary

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689258b9a5a48322b744d9550e1deebe