### PR TITLE
Add traveler and after-work explorer personas page

### DIFF
--- a/calendar/personas/index.md
+++ b/calendar/personas/index.md
@@ -1,0 +1,45 @@
+---
+title: Who We’re Building For: Traveler & After-Work Explorer Personas
+---
+
+# Who We’re Building For: Traveler & After-Work Explorer Personas
+
+To craft an experience that truly resonates, we’ve identified two core user segments:
+
+## 1. Weekend Hosts & Travelers
+**Description:**  
+These users are planning for guests in town or exploring a new city. They need quick, curated suggestions to showcase local culture and make the most of a limited timeframe.
+
+**Key Motivations:**
+- Impress friends or family with unique local experiences  
+- Optimize a weekend itinerary without spending hours researching  
+- Balance popular “must-see” attractions with hidden gems  
+
+**Pain Points:**
+- Information scattered across multiple websites, emails, and social feeds  
+- Generic tourist guides that don’t align with personal interests  
+- Overwhelming choice and limited time to sift through options  
+
+**Day-in-the-Life Scenario:**  
+> Maria is hosting her friends from abroad for a weekend in Stockholm. She wants to plan a Friday evening museum visit, Saturday brunch in Södermalm, and a Sunday hike. Instead of toggling between her inbox, Google searches, and local blogs, she opens our app and immediately gets tailored event suggestions, saves them, and shares the itinerary with her group.
+
+## 2. After-Work Explorers
+**Description:**  
+Busy professionals seeking inspiration for evening or weekend plans to unwind, recharge, and connect with their city.
+
+**Key Motivations:**
+- Break out of the routine of work emails and endless calendar reminders  
+- Discover events that fit a narrow time window (e.g., Friday 6–9 pm)  
+- Find activities that match their current mood—whether it’s relaxing over drinks or trying something new  
+
+**Pain Points:**
+- Lack of time to browse event listings between meetings  
+- Calendar fatigue from managing work appointments  
+- Fear of missing out on worthwhile local happenings  
+
+**Day-in-the-Life Scenario:**  
+> Erik finishes work at 5:30 pm on a Thursday. He opens the app during his commute and swipes through curated suggestions: a street-food market, a pop-up jazz performance, or a late-night museum opening. With one tap, he adds the event to his Google Calendar and gets back to enjoying his evening.
+
+---
+
+[← Back to Overview](../)


### PR DESCRIPTION
## Summary
- add calendar personas page covering weekend hosts & travelers
- document motivations and scenarios for after-work explorers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925cde47e48322bf07291bd575dca5