### PR TITLE
Add mood mapping guide

### DIFF
--- a/calendar/moods/index.md
+++ b/calendar/moods/index.md
@@ -1,0 +1,44 @@
+---
+title: Mood as Your Map: From “Relaxed” to “Energized”
+---
+
+# Mood as Your Map: From “Relaxed” to “Energized”
+
+People don’t just seek events—they seek experiences that match their energy and mindset. That’s why we’ve mapped moods onto a warm-to-cool spectrum, letting you plan with intention and balance.
+
+## The Mood Spectrum
+
+- **Relax & Chill (Warmest)**  
+  Low-energy, restorative activities—think spa sessions, leisurely walks, or cozy coffee dates.  
+- **Explore & Socialize**  
+  Medium-warm experiences such as street markets, gallery strolls, or casual meetups with friends.  
+- **Focus & Learn**  
+  Cooler-toned events for growth and productivity—workshops, lectures, or co-working pop-ups.  
+- **Active & Energized (Coolest)**  
+  High-energy pursuits like sports games, fitness classes, or dance nights.
+
+## Visualizing Your Month with a Heat Map
+
+On the **Month View**, each day is shaded according to your planned or suggested mood mix.  
+- **Warm hues** indicate more relaxation or social time.  
+- **Cool hues** show days heavy on learning or high-energy activities.  
+- Mixed days blend colors to reflect balanced schedules.
+
+This at-a-glance view helps you spot when you’re overdue for downtime or have room to add more adventure.
+
+## How Moods Guide Discovery
+
+1. **Filter by Mood**  
+   Slide the mood selector to show only events matching your desired energy level.  
+2. **Dynamic Adjustments**  
+   As you add events, the heat map and daily mood totals update in real time.  
+3. **Well-Being Insights**  
+   Periodic summaries can nudge you to rebalance—e.g., “You’ve planned four high-energy days in a row; consider a chill activity next.”
+
+## Building Healthier, Happier Calendars
+
+By framing event suggestions in terms of how they make you feel, we turn planning into a personalized wellness tool. Whether you need a calm Sunday or a pump-up Saturday, your mood map has you covered.
+
+---
+
+[← Back to Overview](../)


### PR DESCRIPTION
## Summary
- add calendar/moods index page detailing mood spectrum and heat map visualization

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925d2c55cc8322a990c34cdabf4a59