### PR TITLE
Add market analysis page

### DIFF
--- a/calendar/market-analysis/index.md
+++ b/calendar/market-analysis/index.md
@@ -1,0 +1,72 @@
+---
+title: Where We Stand: Market Landscape & Competitive Analysis
+---
+
+# Where We Stand: Market Landscape & Competitive Analysis
+
+Understanding the competitive landscape and market opportunity is essential for positioning our AI-driven, community-powered event planner. In this article, we survey existing solutions, compare key features, conduct a SWOT analysis, estimate market size, and outline go-to-market strategies by region.
+
+## Competitor Feature Matrix
+
+| Feature / Platform                  | Google Calendar | Apple Calendar | Facebook Events | Meetup               | Resident Advisor |
+|-------------------------------------|-----------------|----------------|-----------------|----------------------|------------------|
+| **Calendar-First UI**               | ✓ basic         | ✓ basic        | ✕               | ✕                    | ✕                |
+| **Event Discovery**                 | ✓ via Gmail     | ✕              | ✓ (social)      | ✓                    | ✓                |
+| **Personalization & Mood Mapping**  | ✕               | ✕              | ✕               | ✕                    | ✕                |
+| **LLM-Powered Parsing**             | ✕               | ✕              | ✕               | ✕                    | ✕                |
+| **Community-Driven Wiki**           | ✕               | ✕              | ✕               | ✓ (groups only)      | ✕                |
+| **Smart, Chained Recommendations**  | ✕               | ✕              | ✕               | ✕                    | ✕                |
+| **Non-Intrusive Integrations**      | ✓ (export)      | ✓ (export)     | ✕               | ✕                    | ✕                |
+| **Ticketing & Resale**              | ✕               | ✕              | ✓ (FB Pay)      | ✕                    | ✓ (primary)      |
+
+## SWOT Analysis
+
+### Strengths
+- **Unique Value Proposition:** Calendar-first, mood-based UI with AI parsing and community curation.  
+- **Low Intrusion:** No feed notifications; users stay in control.  
+- **Scalability:** Wiki model plus LLM pipeline enables rapid growth.
+
+### Weaknesses
+- **Initial Content Gaps:** Building event coverage from scratch may lag established platforms.  
+- **Dependency on Contributions:** Quality relies on active community and moderators.  
+- **Technical Complexity:** LLM parsing and geocoding require robust back-end infrastructure.
+
+### Opportunities
+- **Underserved Segments:** Travelers and after-work planners lack tailored discovery tools.  
+- **Partnerships:** Local cultural institutions and bloggers can drive early adoption.  
+- **Ticketing Add-Ons:** Future revenue from affiliate sales and community exchanges.
+
+### Threats
+- **Platform Lock-In:** Google and Facebook control vast amounts of event data.  
+- **Privacy Concerns:** Users wary of granting email-based services access.  
+- **Competitive Response:** Established players could add similar features.
+
+## Market Sizing
+
+- **Total Addressable Market (TAM):**  
+  ~2 billion smartphone users globally who attend social events annually.  
+- **Serviceable Available Market (SAM):**  
+  300 million travelers and urban professionals in Europe & North America.  
+- **Serviceable Obtainable Market (SOM):**  
+  20 million active users within the first 3 years, targeting major metro areas.
+
+## Go-to-Market Strategies by Region
+
+### Europe
+1. **City Launch Pilots:** Stockholm, Berlin, Amsterdam—partner with cultural blogs and tourist boards.  
+2. **Blogger & Influencer Outreach:** Feature local guides and run co-branded “weekend itineraries.”  
+3. **University Partnerships:** Tap into student communities for early adoption and feedback.
+
+### North America
+1. **Tech Hub Rollouts:** San Francisco, New York, Chicago—leverage startup meetups and coworking spaces.  
+2. **Event Sponsorships:** Sponsor niche festivals or local markets in target cities.  
+3. **Referral Incentives:** Reward users for inviting friends and sharing itineraries.
+
+### Asia-Pacific
+1. **Local Language Adaptation:** Prioritize Tokyo, Seoul, and Singapore with localized content and moods.  
+2. **Tourism Tie-Ins:** Partner with travel agencies to offer app as a value-add for city tours.  
+3. **Mobile-First Partnerships:** Work with mobile carriers or payment apps to bundle the service.
+
+---
+
+[← Back to Overview](../)


### PR DESCRIPTION
## Summary
- add calendar market analysis page with competitor matrix and regional go-to-market strategies

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925e0c9be88322995611021df5e551