### PR TITLE
Rename calendar article to City Outing Calendar

### DIFF
--- a/calendar/index.md
+++ b/calendar/index.md
@@ -1,8 +1,8 @@
 ---
-title: Planning Your City Adventure—An AI-Driven, Community-Powered Approach
+title: City Outing Calendar
 ---
 
-# Planning Your City Adventure—An AI-Driven, Community-Powered Approach
+# City Outing Calendar
 
 Welcome to the future of event planning! In a world of fragmented calendars and endless online feeds, our app brings everything together in one simple, user-friendly experience. We start with a calendar you’ll actually love, powered by community contributions and intelligent AI, all designed to get you **out** of your phone and **into** the real world.
 

--- a/index.md
+++ b/index.md
@@ -41,8 +41,8 @@ A collection of ideas on creating better map-focused sites for local businesses.
 
 [Go to full text →](/maps/index.md)
 
-## Planning Your City Adventure—An AI-Driven, Community-Powered Approach
-An overview of a community-fed, AI-enhanced calendar that links nine deep-dive articles to help you plan richer outings.
+## City Outing Calendar
+A community-fed, AI-powered calendar for discovering and planning city adventures.
 
 [Go to full text →](/calendar/index.md)
 


### PR DESCRIPTION
## Summary
- Shorten calendar article title to "City Outing Calendar"
- Update home page entry and description to match concise title and style

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle directory)*
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6892613136cc8322a1962a06f6804ddc