### PR TITLE
Add generic favicon placeholder

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<link rel="icon" href="{{ '/favicon.svg' | relative_url }}" type="image/svg+xml">

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#cccccc"/>
+  <text x="8" y="12" font-size="10" text-anchor="middle" fill="#666666">I</text>
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder SVG favicon to the site
- reference the favicon through a custom head include

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68934e6c9f7483228535c113446db7cd