### PR TITLE
Use assets folder for calendar images

### DIFF
--- a/calendar/calendar-ui/index.md
+++ b/calendar/calendar-ui/index.md
@@ -2,6 +2,8 @@
 title: A Calendar You’ll Actually Love: Designing the Calendar-First UI
 ---
 
+![Calendar-First UI](/calendar/assets/calendar-ui.png)
+
 # A Calendar You’ll Actually Love: Designing the Calendar-First UI
 
 Your calendar is the home screen—it should be informative, uncluttered, and intuitive at any zoom level. In this article, we explore how a calendar-first approach can transform discovery and planning.

--- a/calendar/community/index.md
+++ b/calendar/community/index.md
@@ -2,6 +2,8 @@
 title: Building the World’s Event Wiki: Community Contributions & Curation
 ---
 
+![Community Curation](/calendar/assets/community.png)
+
 # Building the World’s Event Wiki: Community Contributions & Curation
 
 To keep our event database fresh, accurate, and inclusive, we’ve adopted a wiki-style model where community members play key roles in contributing and curating content.

--- a/calendar/email-llm/index.md
+++ b/calendar/email-llm/index.md
@@ -2,6 +2,8 @@
 title: Inbox → Insight: Email Forwarding & LLM-Powered Event Extraction
 ---
 
+![Email to LLM Pipeline](/calendar/assets/email-llm.png)
+
 # Inbox → Insight: Email Forwarding & LLM-Powered Event Extraction
 
 Transforming scattered event notifications into structured suggestions is at the heart of our discovery engine. This article dives into how a simple email-forwarding workflow and an LLM-based parsing pipeline deliver privacy-safe, high-quality event data.

--- a/calendar/index.md
+++ b/calendar/index.md
@@ -2,7 +2,7 @@
 title: Planning Your City Adventure—An AI-Driven, Community-Powered Concept
 ---
 
-![City Adventure Calendar Concept](/calendar/main.png)
+![City Adventure Calendar Concept](/calendar/assets/main.png)
 
 # Planning Your City Adventure—An AI-Driven, Community-Powered Concept
 

--- a/calendar/integrations/index.md
+++ b/calendar/integrations/index.md
@@ -2,6 +2,8 @@
 title: Staying Out, Not Stuck In: Integrations & Non-Intrusive Reminders
 ---
 
+![Integrations](/calendar/assets/integrations.png)
+
 # Staying Out, Not Stuck In: Integrations & Non-Intrusive Reminders
 
 Our app’s mission is to help you plan and get out—without trapping you in another endless feed of notifications. In this article, we examine how seamless integrations and light-touch alerts keep you on time without cluttering your screen.

--- a/calendar/market-analysis/index.md
+++ b/calendar/market-analysis/index.md
@@ -2,6 +2,8 @@
 title: Where We Stand: Market Landscape & Competitive Analysis
 ---
 
+![Market Analysis](/calendar/assets/market-analysis.png)
+
 # Where We Stand: Market Landscape & Competitive Analysis
 
 Understanding the competitive landscape and market opportunity is essential for positioning our AI-driven, community-powered event planner. In this article, we survey existing solutions, compare key features, conduct a SWOT analysis, estimate market size, and outline go-to-market strategies by region.

--- a/calendar/moods/index.md
+++ b/calendar/moods/index.md
@@ -2,6 +2,8 @@
 title: Mood as Your Map: From “Relaxed” to “Energized”
 ---
 
+![Mood Map](/calendar/assets/moods.png)
+
 # Mood as Your Map: From “Relaxed” to “Energized”
 
 People don’t just seek events—they seek experiences that match their energy and mindset. That’s why we’ve mapped moods onto a warm-to-cool spectrum, letting you plan with intention and balance.

--- a/calendar/personas/index.md
+++ b/calendar/personas/index.md
@@ -2,6 +2,8 @@
 title: Who We’re Building For: Traveler & After-Work Explorer Personas
 ---
 
+![User Personas](/calendar/assets/personas.png)
+
 # Who We’re Building For: Traveler & After-Work Explorer Personas
 
 To craft an experience that truly resonates, we’ve identified two core user segments:

--- a/calendar/smart-suggestions/index.md
+++ b/calendar/smart-suggestions/index.md
@@ -2,6 +2,8 @@
 title: Smart Suggestions: Personalization & Chained Event Recommendations
 ---
 
+![Smart Suggestions](/calendar/assets/smart-suggestions.png)
+
 # Smart Suggestions: Personalization & Chained Event Recommendations
 
 Delivering the right events at the right time takes more than a simple list—it requires intelligent ranking, personalized filtering, and context-aware sequencing. In this article, we break down how our app transforms raw event data into curated, dynamic suggestions.

--- a/calendar/ticketing/index.md
+++ b/calendar/ticketing/index.md
@@ -2,6 +2,8 @@
 title: Money Moves & Future Features: Ticket Sales, Exchanges & Beyond
 ---
 
+![Ticketing Roadmap](/calendar/assets/ticketing.png)
+
 # Money Moves & Future Features: Ticket Sales, Exchanges & Beyond
 
 While our app starts as a purely planning tool, a robust ticketing ecosystem is a natural next step. In this article, we outline a phased roadmap for monetization, community-driven exchanges, and eventual in-app ticket sales and event creation.


### PR DESCRIPTION
## Summary
- Fix main calendar page to load main.png from new assets folder
- Add illustrative images to all calendar subarticle pages

## Testing
- `jekyll build` *(command not found)*
- `bundle exec jekyll build` *(missing Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_68935988a0a48322acef13574664af07